### PR TITLE
Fix-up content hash

### DIFF
--- a/src/server/util/hashing.ts
+++ b/src/server/util/hashing.ts
@@ -17,7 +17,8 @@ export function calculateContentHash(
     const signatures = clone["signatures"];
     delete clone["signatures"];
 
-    if (clone["hashes"]?.["sha256"] !== undefined) {
+    // If there's an lpdu field under hashes, keep it.
+    if (clone["hashes"]?.["lpdu"] !== undefined) {
         clone["hashes"] = {lpdu: clone["hashes"]["lpdu"]};
     } else {
         delete clone["hashes"];


### PR DESCRIPTION
I *think* the content hash is being calculated slightly incorrectly. My reading is that the `lpdu` field of `hashes` should be kept *if* it exists. This is checking if the `sha256` field eixsts, but then keeps the `lpdu` field.