### PR TITLE
Check validity of events as a participating server.

### DIFF
--- a/src/server/models/room/ParticipantRoom.ts
+++ b/src/server/models/room/ParticipantRoom.ts
@@ -107,13 +107,12 @@ export class ParticipantRoom implements Room {
         return new FederationClient(this.hubDomain).sendLinearizedPdus([event]);
     }
 
-    public async receiveEvent(event: PDU | LinearizedPDU): Promise<void> {
+    public async receiveEvent(event: PDU): Promise<void> {
         if (this.hubDomain === Runtime.signingKey.serverName) {
             throw new Error("Runtime error: Override issue - not receiving events in a HubRoom");
         }
 
         // Check the event is valid.
-        // @ts-ignore
         await this.roomVersion.checkValidity(event, this.keyStore);
 
         // otherwise it should be a PDU

--- a/src/server/models/room/ParticipantRoom.ts
+++ b/src/server/models/room/ParticipantRoom.ts
@@ -112,12 +112,16 @@ export class ParticipantRoom implements Room {
             throw new Error("Runtime error: Override issue - not receiving events in a HubRoom");
         }
 
+        // Check the event is valid.
+        // @ts-ignore
+        await this.roomVersion.checkValidity(event, this.keyStore);
+
         // otherwise it should be a PDU
         const fullEvent: MatrixEvent = {
             ...(event as PDU),
             event_id: `$${calculateReferenceHash(this.roomVersion.redact(event))}`,
         };
-        await this.timeline.insertEvents([fullEvent]);
+        await this.timeline.insertEvents([fullEvent]); // checks auth internally
     }
 
     public getEvent(eventId: string): MatrixEvent | undefined {


### PR DESCRIPTION
It is rather hard to trace, but we weren't calling `checkValidity` when receiving events as a participant server. The hub server calls this via [`inject`](https://github.com/matrix-org/eigen-server/blob/a615521803ba0aa4797e24163714ff6b565c0334/src/server/models/room/HubRoom.ts#L160), which gets used in [`createRoomFromState`](https://github.com/matrix-org/eigen-server/blob/a615521803ba0aa4797e24163714ff6b565c0334/src/server/models/room/HubRoom.ts#L333). This is properly done for the state given when [accepting an invite](https://github.com/matrix-org/eigen-server/blob/a615521803ba0aa4797e24163714ff6b565c0334/src/server/InviteStore.ts#L32), but [not for the join itself](https://github.com/matrix-org/eigen-server/blob/a615521803ba0aa4797e24163714ff6b565c0334/src/server/InviteStore.ts#L44).

I had a lot of trouble chasing around the validity checks, I'm not 100% sure this is the proper spot for it TBH.